### PR TITLE
use userPrincipalName for nickname

### DIFF
--- a/OAuth/ResourceOwner/AzureV2ResourceOwner.php
+++ b/OAuth/ResourceOwner/AzureV2ResourceOwner.php
@@ -31,7 +31,7 @@ class AzureV2ResourceOwner extends GenericOAuth2ResourceOwner
     protected $paths = array(
         'identifier'    => 'id',
         'email'         => 'mail',
-        'nickname'      => 'mail',
+        'nickname'      => 'userPrincipalName',
         'realname'      => 'displayName',
         'firstName'     => 'givenName',
         'lastName'      => 'surname'


### PR DESCRIPTION
> userPrincipalName	String	The user principal name (UPN) of the user. The UPN is an Internet-style login name for the user based on the Internet standard RFC 822. By convention, this should map to the user's email name. The general format is alias@domain, where domain must be present in the tenant’s collection of verified domains. This property is required when a user is created. The verified domains for the tenant can be accessed from the verifiedDomains property of organization. Supports $filter and $orderby.

https://graph.microsoft.io/en-us/docs/api-reference/v1.0/resources/user